### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
+## Code of Conduct
+
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
 ## Our Development Process
 We sync from an internal codebase, which is the source of truth for this
 project. We will apply pull requests to this codebase.


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

why make this change?:
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve the [fb-caffe-exts community profile
checklist](https://github.com/facebook/fb-caffe-exts/community) and increase the visibility of our COC.

test plan:
Viewing it on my branch -
![screen shot 2017-12-20 at 9 10 27 am](https://user-images.githubusercontent.com/1114467/34219485-2d3f4622-e566-11e7-8c5a-8009b34fdadc.png)
![screen shot 2017-12-20 at 9 12 25 am](https://user-images.githubusercontent.com/1114467/34219486-2d566bfe-e566-11e7-9f7f-8525329a857e.png)

issue:
internal task t23481323